### PR TITLE
ACD-178: Display midjourney results

### DIFF
--- a/aiconsole/materials/core/api_midjourney.py
+++ b/aiconsole/materials/core/api_midjourney.py
@@ -6,7 +6,7 @@ Always prefer this to other discord libraries and access methods.
 from aiconsole.materials.tools.midjourney import MidJourneyAPI
 
 
-def create_image(prompt: str):
+def create_image(prompt: str) -> list[str]:
     """
     This will wait for images to be generated and download them for display.
 
@@ -14,13 +14,13 @@ def create_image(prompt: str):
 
     ```python
     import api_midjourney
-    api_midjourney.create_image('Wild boar --ar 1:1') # do not add "/imagine prompt:" at the begining
+    image_paths = api_midjourney.create_image('Wild boar --ar 1:1') # do not add "/imagine prompt:" at the beginning
     ```
     """
     midjourney = MidJourneyAPI()
-    midjourney.create_image(prompt)
+    return midjourney.create_image(prompt)
 
 material = {
-    "usage": "When you have a midjourney prompt and need to create an image from it.",
+    "usage": "When you have a midjourney prompt and need to create an image from it and display images from local path",
 }
 


### PR DESCRIPTION
Displaying doesn't work for now.

Usually after these changes, you can see messages like:
```
I have generated the images. The images have been saved in your local environment under the names:
...
Please check your local files to view them.
```
However, I didn't find a way to force the agent to display them, despite the image display being possible in the chat.