### PR TITLE
Run api call only when path is provided

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -159,12 +159,19 @@ const handleDirPicker = async (event) => {
     return;
   }
 
-  const { cancelled, filePaths } = await dialog.showOpenDialog(window.browserWindow, {
-    properties: ['openDirectory',  'createDirectory'],
-  });
+  try {
+    const { cancelled, filePaths } = await dialog.showOpenDialog(
+      window.browserWindow,
+      {
+        properties: ["openDirectory", "createDirectory"],
+      }
+    );
 
-  if (!cancelled) {
-    return filePaths[0];
+    if (!cancelled && filePaths?.length) {
+      return filePaths[0];
+    }
+  } catch (error) {
+    console.error(error);
   }
 };
 

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -4,7 +4,7 @@ declare global {
   interface Window {
     electron: {
       requestBackendPort: () => Promise<number>;
-      openDirectoryPicker: () => Promise<string>;
+      openDirectoryPicker: () => Promise<string | undefiend>;
     };
   }
 }

--- a/frontend/src/store/ProjectSlice.ts
+++ b/frontend/src/store/ProjectSlice.ts
@@ -35,12 +35,7 @@ export type ProjectSlice = {
   setOpenAiApiKey: (key: string) => Promise<void>;
 };
 
-export const createProjectSlice: StateCreator<
-  AICStore,
-  [],
-  [],
-  ProjectSlice
-> = (set, get) => ({
+export const createProjectSlice: StateCreator<AICStore, [], [], ProjectSlice> = (set, get) => ({
   projectPath: undefined,
   projectName: undefined,
   alwaysExecuteCode: false,
@@ -90,8 +85,13 @@ export const createProjectSlice: StateCreator<
   chooseProject: async (path?: string) => {
     // If we are in electron environment, use electron dialog, otherwise rely on the backend to open the dialog
     if (!path && window?.electron?.openDirectoryPicker) {
-      path = await window?.electron?.openDirectoryPicker();
-      (await Api.chooseProject(path).json()) as { name: string; path: string };
+      const path = await window?.electron?.openDirectoryPicker();
+
+      if (path) {
+        (await Api.chooseProject(path).json()) as { name: string; path: string };
+      }
+
+      return;
     }
 
     (await Api.chooseProject(path).json()) as { name: string; path: string };


### PR DESCRIPTION
### Ticket
[ACD-530](https://10clouds.atlassian.net/browse/ACD-530)

### Description
- When the modal directory was canceled another modal was open automatically

[ACD-530]: https://10clouds.atlassian.net/browse/ACD-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ