### PR TITLE
Add early return if electron picker does not return a path

### DIFF
--- a/frontend/src/store/ProjectSlice.ts
+++ b/frontend/src/store/ProjectSlice.ts
@@ -46,10 +46,7 @@ export const createProjectSlice: StateCreator<AICStore, [], [], ProjectSlice> = 
       alwaysExecuteCode: false,
     }));
 
-    await Promise.all([
-      get().initCommandHistory(),
-      get().initChatHistory(),
-    ]);
+    await Promise.all([get().initCommandHistory(), get().initChatHistory()]);
   },
   closeProject: async () => {
     set(() => ({
@@ -96,12 +93,18 @@ export const createProjectSlice: StateCreator<AICStore, [], [], ProjectSlice> = 
   },
   checkPath: async (pathToCheck?: string) => {
     // If we are in electron environment, use electron dialog, otherwise rely on the backend to open the dialog
-    let path = pathToCheck;
-    if (!path && window?.electron?.openDirectoryPicker) {
-      path = await window?.electron?.openDirectoryPicker();
+    let pathFromElectron;
+
+    if (!pathToCheck && window?.electron?.openDirectoryPicker) {
+      pathFromElectron = await window?.electron?.openDirectoryPicker();
+
+      if (!pathFromElectron) {
+        return;
+      }
     }
 
-    const { is_project, path: tkPath } = await Api.isProjectDirectory(path)
+    const path = pathToCheck || pathFromElectron;
+    const { is_project, path: tkPath } = await Api.isProjectDirectory(path);
     set({
       isProjectDirectory: is_project,
       tempPath: tkPath,


### PR DESCRIPTION
### Ticket
[ACD-550](https://10clouds.atlassian.net/browse/ACD-550)


### Descritption
- add early return when there is no path returned from the electron dir picker

[ACD-550]: https://10clouds.atlassian.net/browse/ACD-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ