### PR TITLE
Display confirmation modal when leaving edited asset

### DIFF
--- a/frontend/src/components/common/ConfirmationModal.tsx
+++ b/frontend/src/components/common/ConfirmationModal.tsx
@@ -20,7 +20,7 @@ import { Button } from './Button';
 import { MouseEventHandler, MouseEvent, useEffect } from 'react';
 
 interface ConfirmationModalProps {
-  onConfirm: MouseEventHandler<HTMLButtonElement>;
+  onConfirm: MouseEventHandler<HTMLButtonElement> | null;
   onClose?: () => void;
   confirmButtonText?: string;
   cancelButtonText?: string;
@@ -49,7 +49,9 @@ export function ConfirmationModal({
   }, [close, isOpened, open]);
 
   const handleConfirm = (event: MouseEvent<HTMLButtonElement>) => {
-    onConfirm(event);
+    if (onConfirm) {
+      onConfirm(event);
+    }
     close();
   };
 

--- a/frontend/src/components/editables/sidebar/SideBarItem.tsx
+++ b/frontend/src/components/editables/sidebar/SideBarItem.tsx
@@ -21,8 +21,9 @@ import { getEditableObjectIcon } from '@/utils/editables/getEditableObjectIcon';
 import { useEditableObjectContextMenu } from '@/utils/editables/useContextMenuForEditable';
 import { useEditablesStore } from '@/store/editables/useEditablesStore';
 import { KeyboardEvent, MouseEvent, useEffect, useRef, useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { getAssetStatusIcon } from '@/utils/editables/getAssetStatusIcon';
+import { useDiscardAssetChangesStore } from '@/store/editables/asset/useDiscardAssetChangesStore';
 
 const SideBarItem = ({
   editableObjectType,
@@ -31,7 +32,9 @@ const SideBarItem = ({
   editableObject: EditableObject;
   editableObjectType: EditableObjectType;
 }) => {
+  const { isChanged, setConfirmCallback } = useDiscardAssetChangesStore();
   const renameEditableObject = useEditablesStore((state) => state.renameEditableObject);
+  const navigate = useNavigate();
 
   const [isEditing, setIsEditing] = useState(false);
   const [isShowingContext, setIsShowingContext] = useState(false);
@@ -113,29 +116,29 @@ const SideBarItem = ({
     showContextMenu()(event);
   }
 
+  const handleInterceptNavigation = (path: string) => (event: MouseEvent) => {
+    if (isChanged) {
+      event.preventDefault();
+      setConfirmCallback(() => navigate(path));
+    }
+  };
+
   return (
-    <div
-      ref={popoverRef}
-      onContextMenu={handleContextMenu}
-      className="max-w-[275px]"
-    >
+    <div ref={popoverRef} onContextMenu={handleContextMenu} className="max-w-[275px]">
       <div className={cn(forced && 'text-primary', disabled && 'opacity-50')}>
         <NavLink
           className={({ isActive, isPending }) => {
             return cn(
               'group flex items-center gap-[12px] overflow-hidden p-[9px] rounded-[8px] cursor-pointer relative  hover:bg-gray-700',
               {
-                'bg-gray-700 text-white ':
-                  isActive || isPending || isShowingContext,
+                'bg-gray-700 text-white ': isActive || isPending || isShowingContext,
               },
             );
           }}
+          onClick={handleInterceptNavigation(`/${editableObjectType}s/${editableObject.id}`)}
           to={`/${editableObjectType}s/${editableObject.id}`}
         >
-          <Icon
-            className="min-w-[24px] min-h-[24px] w-[24px] h-[24px]"
-            style={{ color }}
-          />
+          <Icon className="min-w-[24px] min-h-[24px] w-[24px] h-[24px]" style={{ color }} />
           {/* TODO: add validation for empty input value */}
           {isEditing ? (
             <input
@@ -147,9 +150,7 @@ const SideBarItem = ({
               onChange={(e) => setInputText(e.target.value)}
             />
           ) : (
-            <p className="text-[14px] leading-[18.2px] group-hover:text-white truncate">
-              {editableObject.name}
-            </p>
+            <p className="text-[14px] leading-[18.2px] group-hover:text-white truncate">{editableObject.name}</p>
           )}
           {!isEditing ? extraStuff : null}
 

--- a/frontend/src/store/editables/asset/useDiscardAssetChangesStore.ts
+++ b/frontend/src/store/editables/asset/useDiscardAssetChangesStore.ts
@@ -1,0 +1,36 @@
+// The AIConsole Project
+//
+// Copyright 2023 10Clouds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { create } from 'zustand';
+import { shallow } from 'zustand/shallow';
+
+type Callback = () => void;
+
+interface DiscardStore {
+  isChanged: boolean;
+  confirmCallback: null | Callback;
+  setIsChanged: (value: boolean) => void;
+  setConfirmCallback: (value: null | Callback) => void;
+}
+
+const discardStore = create<DiscardStore>()((set) => ({
+  isChanged: false,
+  confirmCallback: null,
+  setIsChanged: (isChanged: boolean) => set({ isChanged }),
+  setConfirmCallback: (confirmCallback: null | Callback) => set({ confirmCallback }),
+}));
+
+export const useDiscardAssetChangesStore = () => discardStore((state) => state, shallow);

--- a/frontend/src/utils/editables/useAddMenu.tsx
+++ b/frontend/src/utils/editables/useAddMenu.tsx
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useDiscardAssetChangesStore } from '@/store/editables/asset/useDiscardAssetChangesStore';
 import { useContextMenu } from '@/utils/common/useContextMenu';
 import { getEditableObjectColor } from '@/utils/editables/getEditableObjectColor';
 import { MATERIAL_CONTENT_TYPE_ICONS, getEditableObjectIcon } from '@/utils/editables/getEditableObjectIcon';
@@ -22,7 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export function useAddMenu() {
   const { showContextMenu, hideContextMenu, isContextMenuVisible } = useContextMenu();
-
+  const { isChanged, setConfirmCallback } = useDiscardAssetChangesStore();
   const navigate = useNavigate();
   const ChatIcon = getEditableObjectIcon('chat');
   const MaterialNoteIcon = MATERIAL_CONTENT_TYPE_ICONS['static_text'];
@@ -30,47 +31,45 @@ export function useAddMenu() {
   const MaterialPythonAPIIcon = MATERIAL_CONTENT_TYPE_ICONS['api'];
   const AgentIcon = getEditableObjectIcon('agent');
 
+  const handleClick = (path: string) => () => {
+    if (isChanged) {
+      setConfirmCallback(() => navigate(path));
+    } else {
+      navigate(path);
+    }
+  };
+
   function showContextMenuReplacement() {
     return showContextMenu([
       {
         key: 'chat',
         icon: <ChatIcon className="w-4 h-4" style={{ color: getEditableObjectColor('chat') }} />,
         title: 'New Chat ...',
-        onClick: () => {
-          navigate(`/chats/${uuidv4()}`);
-        },
+        onClick: handleClick(`/chats/${uuidv4()}`),
       },
       {
         key: 'note',
         icon: <MaterialNoteIcon className="w-4 h-4" style={{ color: getEditableObjectColor('material') }} />,
         title: 'New Note ...',
-        onClick: () => {
-          navigate(`/materials/new?type=static_text`);
-        },
+        onClick: handleClick(`/materials/new?type=static_text`),
       },
       {
         key: 'dynamic_note',
         icon: <MaterialDynamicNoteIcon className="w-4 h-4" style={{ color: getEditableObjectColor('material') }} />,
         title: 'New Dynamic Note ...',
-        onClick: () => {
-          navigate(`/materials/new?type=dynamic_text`);
-        },
+        onClick: handleClick(`/materials/new?type=dynamic_text`),
       },
       {
         key: 'python_api',
         icon: <MaterialPythonAPIIcon className="w-4 h-4" style={{ color: getEditableObjectColor('material') }} />,
         title: 'New Python API ...',
-        onClick: () => {
-          navigate(`/materials/new?type=api`);
-        },
+        onClick: handleClick(`/materials/new?type=api`),
       },
       {
         key: 'agent',
         icon: <AgentIcon className="w-4 h-4" style={{ color: getEditableObjectColor('agent') }} />,
         title: 'New Agent ...',
-        onClick: () => {
-          navigate(`/agents/new`);
-        },
+        onClick: handleClick(`/agents/new`),
       },
       /*static_text: 'Markdown formated text will be injected into AI context.',
       dynamic_text: 'A python function will generate markdown text to be injected into AI context.',

--- a/frontend/src/utils/editables/useContextMenuForEditable.tsx
+++ b/frontend/src/utils/editables/useContextMenuForEditable.tsx
@@ -23,6 +23,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { useContextMenu } from '../common/useContextMenu';
 import { getAssetStatusIcon } from './getAssetStatusIcon';
+import { useDiscardAssetChangesStore } from '@/store/editables/asset/useDiscardAssetChangesStore';
 
 function createIconForStatus(assetStatus: AssetStatus) {
   const Icon = getAssetStatusIcon(assetStatus);
@@ -41,6 +42,8 @@ export function useEditableObjectContextMenu({
   setIsEditing?: (isEditing: boolean) => void;
 }) {
   const { showContextMenu, hideContextMenu, isContextMenuVisible } = useContextMenu();
+  const { isChanged, setConfirmCallback } = useDiscardAssetChangesStore();
+
   const navigate = useNavigate();
   const location = useLocation();
   const deleteEditableObject = useEditablesStore((state) => state.deleteEditableObject);
@@ -78,7 +81,12 @@ export function useEditableObjectContextMenu({
         icon: <File className="w-4 h-4" />,
         title: 'Open',
         onClick: () => {
-          navigate(`/${editableObjectType}s/${editableObject.id}`);
+          const path = `/${editableObjectType}s/${editableObject.id}`;
+          if (isChanged) {
+            setConfirmCallback(() => navigate(path));
+          } else {
+            navigate(path);
+          }
         },
       });
     }
@@ -88,9 +96,14 @@ export function useEditableObjectContextMenu({
       icon: <Copy className="w-4 h-4" />,
       title: 'Edit as New',
       onClick: () => {
-        navigate(
-          `/${editableObjectType}s/${editableObjectType === 'chat' ? uuidv4() : 'new'}?copy=${editableObject.id}`,
-        );
+        const path = `/${editableObjectType}s/${editableObjectType === 'chat' ? uuidv4() : 'new'}?copy=${
+          editableObject.id
+        }`;
+        if (isChanged) {
+          setConfirmCallback(() => navigate(path));
+        } else {
+          navigate(path);
+        }
       },
     });
 

--- a/frontend/src/utils/projects/useProjectContextMenu.tsx
+++ b/frontend/src/utils/projects/useProjectContextMenu.tsx
@@ -17,11 +17,19 @@
 import { useContextMenu } from '@/utils/common/useContextMenu';
 import { XIcon } from 'lucide-react';
 import { ProjectsAPI } from '@/api/api/ProjectsAPI';
+import { useDiscardAssetChangesStore } from '@/store/editables/asset/useDiscardAssetChangesStore';
 
 export function useProjectContextMenu() {
   const { showContextMenu, hideContextMenu, isContextMenuVisible } = useContextMenu();
+  const { isChanged, setConfirmCallback } = useDiscardAssetChangesStore();
 
-  const handleBackToProjects = () => ProjectsAPI.closeProject();
+  const handleBackToProjects = () => {
+    if (isChanged) {
+      setConfirmCallback(() => ProjectsAPI.closeProject());
+    } else {
+      ProjectsAPI.closeProject();
+    }
+  };
 
   function showContextMenuReplacement() {
     return showContextMenu([


### PR DESCRIPTION
### Ticket

[ACD-588](https://10clouds.atlassian.net/browse/ACD-588)

### Description
- Instead of using a window.confirm I used our custom confirmation dialog so it required an additional zustand store to control discarding changes from multiple places 

### Preview

https://github.com/10clouds/aiconsole/assets/25374390/1f9d77e0-01f9-43ae-bce1-a4f972562911




[ACD-588]: https://10clouds.atlassian.net/browse/ACD-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ