### PR TITLE
[ACD-643] [ACD-646] Revert button does not reset isAssetChanged state/ Overwriting asset displays confirm dialog

### DIFF
--- a/frontend/src/components/editables/assets/AssetEditor.tsx
+++ b/frontend/src/components/editables/assets/AssetEditor.tsx
@@ -40,6 +40,7 @@ import { EditablesAPI } from '../../../api/api/EditablesAPI';
 import { useAssetChanged } from '../../../utils/editables/useAssetChanged';
 import { EditorHeader } from '../EditorHeader';
 import { localStorageTyped } from '@/utils/common/localStorage';
+import { usePrevious } from '@mantine/hooks';
 
 const { setItem } = localStorageTyped<boolean>('isAssetChanged');
 
@@ -119,6 +120,9 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
   const handleDeleteWithInteraction = useDeleteEditableObjectWithUserInteraction(assetType);
   const navigate = useNavigate();
   const isAssetChanged = useAssetChanged();
+  const isPrevAssetChanged = usePrevious(isAssetChanged);
+
+  const wasAssetChangedInitially = !isPrevAssetChanged && isAssetChanged;
 
   const blocker = useBlocker(isAssetChanged);
 
@@ -286,12 +290,12 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
 
   // If edited a core asset, set override and defined in
   useEffect(() => {
-    if (asset && asset.defined_in === 'aiconsole' && isAssetChanged) {
+    if (asset && asset.defined_in === 'aiconsole' && wasAssetChangedInitially) {
       console.log('CORE');
       setSelectedAsset({ ...asset, defined_in: 'project' } as Asset);
       setLastSavedSelectedAsset(undefined);
     }
-  }, [asset, setSelectedAsset, isAssetChanged, setLastSavedSelectedAsset]);
+  }, [asset, setSelectedAsset, wasAssetChangedInitially, setLastSavedSelectedAsset]);
 
   const [hasCore, setHasCore] = useState(false);
 

--- a/frontend/src/components/editables/assets/AssetEditor.tsx
+++ b/frontend/src/components/editables/assets/AssetEditor.tsx
@@ -243,7 +243,6 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
       useAssetStore.setState({ lastSavedSelectedAsset: asset });
       console.log('SHOULD NAVIGATE');
       setNewPath(`/${assetType}s/${asset.id}`);
-      //  navigate(`/${assetType}s/${asset.id}`);
     } else {
       // Reload the asset from server
       const newAsset = await EditablesAPI.fetchEditableObject<Material>({

--- a/frontend/src/components/editables/assets/AssetEditor.tsx
+++ b/frontend/src/components/editables/assets/AssetEditor.tsx
@@ -241,7 +241,6 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
 
     if (lastSavedAsset?.id !== asset.id) {
       useAssetStore.setState({ lastSavedSelectedAsset: asset });
-      console.log('SHOULD NAVIGATE');
       setNewPath(`/${assetType}s/${asset.id}`);
     } else {
       // Reload the asset from server

--- a/frontend/src/components/editables/assets/AssetEditor.tsx
+++ b/frontend/src/components/editables/assets/AssetEditor.tsx
@@ -121,12 +121,21 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
   const navigate = useNavigate();
   const isAssetChanged = useAssetChanged();
   const isPrevAssetChanged = usePrevious(isAssetChanged);
+  const [newPath, setNewPath] = useState<string>('');
 
   const wasAssetChangedInitially = !isPrevAssetChanged && isAssetChanged;
+  const wasAssetUpdate = isPrevAssetChanged && !isAssetChanged;
 
   const blocker = useBlocker(isAssetChanged);
 
   const { reset, proceed, state: blockerState } = blocker || {};
+
+  useEffect(() => {
+    if (wasAssetUpdate && newPath) {
+      navigate(newPath);
+      setNewPath('');
+    }
+  }, [newPath, isAssetChanged, wasAssetUpdate, navigate]);
 
   useEffect(() => {
     setItem(isAssetChanged);
@@ -231,7 +240,10 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
     }
 
     if (lastSavedAsset?.id !== asset.id) {
-      navigate(`/${assetType}s/${asset.id}`);
+      useAssetStore.setState({ lastSavedSelectedAsset: asset });
+      console.log('SHOULD NAVIGATE');
+      setNewPath(`/${assetType}s/${asset.id}`);
+      //  navigate(`/${assetType}s/${asset.id}`);
     } else {
       // Reload the asset from server
       const newAsset = await EditablesAPI.fetchEditableObject<Material>({
@@ -241,9 +253,7 @@ export function AssetEditor({ assetType }: { assetType: AssetType }) {
       setSelectedAsset(newAsset);
       useAssetStore.setState({ lastSavedSelectedAsset: newAsset });
     }
-
-    useAssetStore.setState({ lastSavedSelectedAsset: asset });
-  }, [asset, assetType, isAssetChanged, lastSavedAsset, navigate, setSelectedAsset, updateStatusIfNecessary]);
+  }, [asset, assetType, isAssetChanged, lastSavedAsset, setSelectedAsset, updateStatusIfNecessary]);
 
   const handleDiscardChanges = () => {
     //set last selected asset to the same as selected asset


### PR DESCRIPTION
### Ticket
[ACD-643](https://10clouds.atlassian.net/browse/ACD-643)
[ACD-646](https://10clouds.atlassian.net/browse/ACD-646)

### Description

- `defined_in` should be changed only on the initial change otherwise when reverting changes it will update the reverted asset again,  and again
- navigation was moved from a handler to wait until all states are updated and blocker in in unblocked state

[ACD-643]: https://10clouds.atlassian.net/browse/ACD-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACD-646]: https://10clouds.atlassian.net/browse/ACD-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ