### PR TITLE
Fix/notification issue

### DIFF
--- a/backend/aiconsole/core/settings/project_settings.py
+++ b/backend/aiconsole/core/settings/project_settings.py
@@ -90,7 +90,7 @@ class Settings:
         self._observer.schedule(
             BatchingWatchDogHandler(self.reload, self._global_settings_file_path.name),
             str(self._global_settings_file_path.parent),
-            recursive=True,
+            recursive=False,
         )
 
         if self._project_settings_file_path:
@@ -98,7 +98,7 @@ class Settings:
             self._observer.schedule(
                 BatchingWatchDogHandler(self.reload, self._project_settings_file_path.name),
                 str(self._project_settings_file_path.parent),
-                recursive=True,
+                recursive=False,
             )
 
         self._observer.start()

--- a/backend/aiconsole/utils/BatchingWatchDogHandler.py
+++ b/backend/aiconsole/utils/BatchingWatchDogHandler.py
@@ -23,7 +23,7 @@ import threading
 
 class BatchingWatchDogHandler(watchdog.events.FileSystemEventHandler):
     def __init__(self, reload, extension=".toml"):
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         self.timer = None
         self.reload = reload
         self.extension = extension


### PR DESCRIPTION
Due to the recursive flag, watchdog was also looking into the .aic folder, which contains files that have "setting.toml" in the name (aiconsole_settings.toml) 