### PR TITLE
Fixed back button from assistant view to last used chat task#839

### DIFF
--- a/frontend/src/components/editables/EditorHeader.tsx
+++ b/frontend/src/components/editables/EditorHeader.tsx
@@ -28,7 +28,7 @@ export function EditorHeader({ editable, onRename, children, isChanged, editable
 
   const goBack = () => {
     if (lastUsedChat) {
-      navigate(`/${editableObjectType}s`);
+      navigate(`/chats/${lastUsedChat.id}`);
     }
   };
 


### PR DESCRIPTION
Hi. It didn't work because of wrong routing. 
In Routing, the string "agent" was provided instead of "chat". Additionally, the id of the previously used chat was missing after the slash